### PR TITLE
Opt in to building DocC documentation on Swift Package Index with Swift 6.0

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,3 +2,4 @@ version: 1
 builder:
   configs:
     - documentation_targets: [Compute]
+      swift_version: 6.0


### PR DESCRIPTION
Once merged, I'll manually kick off new builds so you don't have to wait for us to notice the change.

Also, I'd recommend reverting this commit after Xcode 16 reaches general release as this will pin the documentation build *always* to Swift 6, even when we move forward to 6.x. 